### PR TITLE
Decouple from Rocket.Chat repo

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -27,8 +27,9 @@ program
 	.command('logs')
 	.description('Generate history.json')
 	.option('-h, --head_name <name>', 'Name of the new release. Will rename the current HEAD section')
-	.action(async function({head_name}) {
-		logs({ ...await getRepoInfo(), headName: head_name });
+	.option('-t, --min_tag <tag>', 'Minimum tag to scrap the history')
+	.action(async function({head_name, min_tag}) {
+		logs({ ...await getRepoInfo(), headName: head_name, minTag: min_tag });
 	});
 
 program

--- a/package-lock.json
+++ b/package-lock.json
@@ -622,6 +622,23 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
+    "git-up": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
+      "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "parse-url": "^5.0.0"
+      }
+    },
+    "git-url-parse": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
+      "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+      "requires": {
+        "git-up": "^4.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -801,6 +818,14 @@
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
       "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
+    "is-ssh": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
+      "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+      "requires": {
+        "protocols": "^1.1.0"
+      }
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -967,6 +992,11 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
     },
+    "normalize-url": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
+      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -1044,6 +1074,26 @@
         "semver": "^5.1.0"
       }
     },
+    "parse-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
+      "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
+      }
+    },
+    "parse-url": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
+      "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+      "requires": {
+        "is-ssh": "^1.3.0",
+        "normalize-url": "^3.3.0",
+        "parse-path": "^4.0.0",
+        "protocols": "^1.4.0"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -1078,6 +1128,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+    },
+    "protocols": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
+      "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg=="
     },
     "pseudomap": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,7 +169,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
     "camelcase": {
@@ -936,7 +936,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -1046,7 +1046,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -1131,7 +1131,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "requires": {
         "caller-path": "^0.1.0",
@@ -1237,7 +1237,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@octokit/rest": "^16.3.0",
     "commander": "^2.19.0",
     "eslint": "^5.11.1",
+    "git-url-parse": "^11.1.2",
     "inquirer": "^5.2.0",
     "progress": "^2.0.3",
     "semver": "^5.6.0",

--- a/src/logs.js
+++ b/src/logs.js
@@ -6,6 +6,7 @@ const _ = require('underscore');
 const git = require('simple-git/promise')(process.cwd());
 const octokit = require('@octokit/rest')();
 
+// TODO what to do with this?
 const minTag = '0.55.0-rc.0';
 const commitRegexString = '(^Merge pull request #([0-9]+) from )|( \\(#([0-9]+)\\)$)';
 const commitRegex = new RegExp(commitRegexString);
@@ -54,8 +55,8 @@ octokit.authenticate({
 	type: 'token',
 	token: process.env.GITHUB_TOKEN
 });
-let owner = 'RocketChat';
-let repo = 'Rocket.Chat';
+let owner = '';
+let repo = '';
 
 function promiseRetryRateLimit(promiseFn, retryWait = 60000) {
 	return new Promise((resolve, reject) => {
@@ -262,7 +263,7 @@ async function getMissingTags() {
 	return _.pick(tags, missingTags);
 }
 
-module.exports = function({headName = 'HEAD', owner:_owner = 'RocketChat', repo:_repo = 'Rocket.Chat', getMetadata = () => Promise.resolve({}) }) {
+module.exports = function({headName = 'HEAD', owner:_owner = '', repo:_repo = '', getMetadata = () => Promise.resolve({}) }) {
 	owner = _owner;
 	repo = _repo;
 

--- a/src/logs.js
+++ b/src/logs.js
@@ -159,8 +159,25 @@ function getPRNumberFromMessage(message, item) {
 	return number;
 }
 
+function getCommitRange(from, to) {
+	if (!from && !to) {
+		console.error('Invalid commits for range');
+		process.exit(1);
+	}
+
+	if (from && to) {
+		return `${ from }...${ to }`;
+	}
+
+	if (!from) {
+		return `${ to }^@`;
+	}
+
+	return `${ from }...HEAD`;
+}
+
 async function getPullRequests(from, to) {
-	const logParams = ['--no-decorate', '--graph', '-E', `--grep=${ commitRegexString }`, `${ from }...${ to }`];
+	const logParams = ['--no-decorate', '--graph', '-E', `--grep=${ commitRegexString }`, getCommitRange(from, to)];
 	logParams.format = {
 		hash: '%H',
 		date: '%ai',
@@ -245,7 +262,7 @@ async function getTags({ minTag }) {
 				before: index ? tags[--index] : null
 			};
 		})
-		.filter(item => item.tag === 'HEAD' || (minTag && semver.gte(item.tag, minTag)))
+		.filter(item => item.tag === 'HEAD' || !minTag || semver.gte(item.tag, minTag))
 		.reduce((value, item) => {
 			value[item.tag] = item;
 			return value;

--- a/src/md.js
+++ b/src/md.js
@@ -93,7 +93,7 @@ function renderPRs(prs, historyDataReleasesOriginal, tag) {
 	});
 
 	const olderReleases = otherTags.map(t => historyDataReleasesOriginal[t]);
-	prs = prs.filter(p => !olderReleases.some(r => r.pull_requests.some(p2 => p2.pr === p.pr)));
+	prs = prs.filter(p => p.manual || !olderReleases.some(r => r.pull_requests.some(p2 => p2.pr === p.pr)));
 
 	const data = [];
 	const groupedPRs = groupPRs(prs);
@@ -222,7 +222,7 @@ module.exports = async function({tag, write = true, title = true} = {}) {
 		historyDataReleases[tag] = historyDataReleases[tag] || {
 			pull_requests: []
 		};
-		historyDataReleases[tag].pull_requests.unshift(...historyManualData[tag]);
+		historyDataReleases[tag].pull_requests.unshift(...historyManualData[tag].map((pr) => ({ manual: true, ...pr })));
 	});
 
 	Object.values(historyDataReleases).forEach(value => {

--- a/src/md.js
+++ b/src/md.js
@@ -201,7 +201,6 @@ const getVersionObj = (release, tag, title, owner, repo, tagPrefix = '#') => {
 
 	if (noMainRelease) {
 		if (title) {
-			// result.push(`\n${ tagPrefix } ${ tagText } (Under Release Candidate Process)`);
 			version.title = `${ tagPrefix } ${ tagText } (Under Release Candidate Process)`;
 		}
 	} else {

--- a/src/set-version.js
+++ b/src/set-version.js
@@ -34,6 +34,7 @@ class Houston {
 		this.version = version;
 
 		this.getMetadata = () => Promise.resolve({});
+		this.customMarkdown = (data) => Promise.resolve(data);
 
 		if (!this.version) {
 			this.readVersionFromPackageJson();
@@ -77,6 +78,10 @@ class Houston {
 
 		if (houston.metadata) {
 			this.getMetadata = require(path.resolve(process.cwd(), houston.metadata));
+		}
+
+		if (houston.markdown) {
+			this.customMarkdown = require(path.resolve(process.cwd(), houston.markdown));
 		}
 	}
 
@@ -459,7 +464,7 @@ class Houston {
 
 	async updateHistory() {
 		await logs({headName: this.version, getMetadata: this.getMetadata /*, owner: this.owner, repo: this.repo*/});
-		await md();
+		await md({ customMarkdown: this.customMarkdown });
 		await this.shouldCommitFiles({amend: true});
 	}
 

--- a/src/set-version.js
+++ b/src/set-version.js
@@ -32,6 +32,7 @@ class Houston {
 		this.owner = owner;
 		this.repo = repo;
 		this.version = version;
+		this.minTag = '';
 
 		this.getMetadata = () => Promise.resolve({});
 		this.customMarkdown = (data) => Promise.resolve(data);
@@ -82,6 +83,10 @@ class Houston {
 
 		if (houston.markdown) {
 			this.customMarkdown = require(path.resolve(process.cwd(), houston.markdown));
+		}
+
+		if (houston.minTag) {
+			this.minTag = houston.minTag;
 		}
 	}
 
@@ -463,7 +468,7 @@ class Houston {
 	}
 
 	async updateHistory() {
-		await logs({headName: this.version, getMetadata: this.getMetadata, owner: this.owner, repo: this.repo });
+		await logs({headName: this.version, getMetadata: this.getMetadata, owner: this.owner, repo: this.repo, minTag: this.minTag });
 		await md({ customMarkdown: this.customMarkdown, owner: this.owner, repo: this.repo });
 		await this.shouldCommitFiles({amend: true});
 	}

--- a/src/set-version.js
+++ b/src/set-version.js
@@ -463,8 +463,8 @@ class Houston {
 	}
 
 	async updateHistory() {
-		await logs({headName: this.version, getMetadata: this.getMetadata /*, owner: this.owner, repo: this.repo*/});
-		await md({ customMarkdown: this.customMarkdown });
+		await logs({headName: this.version, getMetadata: this.getMetadata, owner: this.owner, repo: this.repo });
+		await md({ customMarkdown: this.customMarkdown, owner: this.owner, repo: this.repo });
 		await this.shouldCommitFiles({amend: true});
 	}
 
@@ -613,5 +613,8 @@ class Houston {
 	}
 }
 
-const houston = new Houston();
-houston.init().catch(error => console.error(error));
+module.exports = function({ owner, repo }) {
+	const houston = new Houston({ owner, repo });
+	houston.init().catch(error => console.error(error));
+};
+

--- a/src/set-version.js
+++ b/src/set-version.js
@@ -508,7 +508,7 @@ class Houston {
 			name: 'pushTag'
 		}]);
 
-		const body = await md({tag: this.version, write: false, title: false});
+		const body = await md({tag: this.version, write: false, title: false, owner: this.owner, repo: this.repo});
 		if (answers.pushTag) {
 			try {
 				const release = await octokit.repos.getReleaseByTag({owner: this.owner, repo: this.repo, tag: this.version});
@@ -548,7 +548,7 @@ class Houston {
 			name: 'create'
 		}]);
 
-		const body = await md({tag: this.version, write: false, title: false});
+		const body = await md({tag: this.version, write: false, title: false, owner: this.owner, repo: this.repo});
 		if (answers.create) {
 			console.log('Creating draft release');
 			await octokit.repos.createRelease({
@@ -571,7 +571,7 @@ class Houston {
 			name: 'create'
 		}]);
 
-		const body = await md({tag: this.version, write: false, title: false});
+		const body = await md({tag: this.version, write: false, title: false, owner: this.owner, repo: this.repo});
 		if (answers.create) {
 			console.log('Creating pull request');
 			const pr = await octokit.pullRequests.create({

--- a/src/set-version.js
+++ b/src/set-version.js
@@ -33,6 +33,8 @@ class Houston {
 		this.repo = repo;
 		this.version = version;
 
+		this.getMetadata = () => Promise.resolve({});
+
 		if (!this.version) {
 			this.readVersionFromPackageJson();
 		}
@@ -71,6 +73,10 @@ class Houston {
 			houston.updateFiles.forEach((file) => {
 				files.push(file);
 			});
+		}
+
+		if (houston.metadata) {
+			this.getMetadata = require(path.resolve(process.cwd(), houston.metadata));
 		}
 	}
 
@@ -452,7 +458,7 @@ class Houston {
 	}
 
 	async updateHistory() {
-		await logs({headName: this.version/*, owner: this.owner, repo: this.repo*/});
+		await logs({headName: this.version, getMetadata: this.getMetadata /*, owner: this.owner, repo: this.repo*/});
 		await md();
 		await this.shouldCommitFiles({amend: true});
 	}

--- a/src/set-version.js
+++ b/src/set-version.js
@@ -513,7 +513,7 @@ class Houston {
 			name: 'pushTag'
 		}]);
 
-		const body = await md({tag: this.version, write: false, title: false, owner: this.owner, repo: this.repo});
+		const body = await md({tag: this.version, write: false, title: false, owner: this.owner, repo: this.repo, customMarkdown: this.customMarkdown});
 		if (answers.pushTag) {
 			try {
 				const release = await octokit.repos.getReleaseByTag({owner: this.owner, repo: this.repo, tag: this.version});
@@ -553,7 +553,7 @@ class Houston {
 			name: 'create'
 		}]);
 
-		const body = await md({tag: this.version, write: false, title: false, owner: this.owner, repo: this.repo});
+		const body = await md({tag: this.version, write: false, title: false, owner: this.owner, repo: this.repo, customMarkdown: this.customMarkdown});
 		if (answers.create) {
 			console.log('Creating draft release');
 			await octokit.repos.createRelease({
@@ -576,7 +576,7 @@ class Houston {
 			name: 'create'
 		}]);
 
-		const body = await md({tag: this.version, write: false, title: false, owner: this.owner, repo: this.repo});
+		const body = await md({tag: this.version, write: false, title: false, owner: this.owner, repo: this.repo, customMarkdown: this.customMarkdown});
 		if (answers.create) {
 			console.log('Creating pull request');
 			const pr = await octokit.pullRequests.create({


### PR DESCRIPTION
- [x] Replace `getEngineVersions` by a `getMetadata` function defined on the original repo's `package.json` file property `houston.metadata`
- [x] Replace [engine versions markdown generator](https://github.com/RocketChat/Rocket.Chat.Houston/blob/99ead3c9c95b3e8abdddfc3dcbf59d2caba8cc72/src/md.js#L279) by a "custom markdown" defined on the original repo's `package.json` file property `houston.markdown`
- [x] Support `minTag` config